### PR TITLE
Raising error when dependency_map contains redundant dependencies.

### DIFF
--- a/pordego_dependency/dependency_analysis.py
+++ b/pordego_dependency/dependency_analysis.py
@@ -1,8 +1,11 @@
 from logging import getLogger
 
+from collections import defaultdict
+
 from pordego_dependency.analysis_result import AnalysisResult
 from pordego_dependency.analyzer import Analyzer
-from pordego_dependency.dependency_tools import filter_local_dependencies, filter_ignored_dependencies
+from pordego_dependency.dependency_tools import filter_local_dependencies, filter_ignored_dependencies, \
+    find_redundant_dependency_names
 
 logger = getLogger(__name__)
 
@@ -16,23 +19,27 @@ class DependencyAnalyzer(Analyzer):
         for dependency_input in self._config.dependency_inputs:
             dependencies = package_dependency_map[dependency_input.package_path]
             local_depends = filter_local_dependencies(dependencies, self._config.source_paths)
-            if dependency_input.allowed_dependency is not None:
-                non_ignored_depends = filter_ignored_dependencies(local_depends,
-                                                                  dependency_input.allowed_dependency)
+            allowed_dependency_names = dependency_input.allowed_dependency
+            if allowed_dependency_names is not None:
+                non_ignored_depends = filter_ignored_dependencies(local_depends, allowed_dependency_names)
                 result.update_invalid_dependencies(non_ignored_depends)
+
+                redundant_dependency_names = find_redundant_dependency_names(local_depends, allowed_dependency_names)
+                result.update_redundant_dependency_names(dependency_input.input_package, redundant_dependency_names)
         return result
 
 
 class DependencyAnalysisResult(AnalysisResult):
     def __init__(self):
         self.invalid_dependencies = set()
+        self.redundant_dependencies = defaultdict(set)
 
     def update_invalid_dependencies(self, invalid_deps):
         self.invalid_dependencies |= set(invalid_deps)
 
     @property
     def has_error(self):
-        return any([self.invalid_dependencies])
+        return any([self.invalid_dependencies]) or any(self.redundant_dependencies)
 
     @property
     def error_messages(self):
@@ -41,4 +48,10 @@ class DependencyAnalysisResult(AnalysisResult):
             errors.append("Found {} dependency violations:\n{}".format(len(self.invalid_dependencies),
                                                                        "\n".join([str(i) for i in
                                                                                   self.invalid_dependencies])))
+        if self.redundant_dependencies:
+            for package, dependencies in self.redundant_dependencies.iteritems():
+                errors.append("Following dependencies of {} are redundant: {}".format(package, ", ".join(dependencies)))
         return errors
+
+    def update_redundant_dependency_names(self, input_package, redundant_dependency_names):
+        self.redundant_dependencies[input_package] |= redundant_dependency_names

--- a/pordego_dependency/dependency_analysis.py
+++ b/pordego_dependency/dependency_analysis.py
@@ -25,7 +25,8 @@ class DependencyAnalyzer(Analyzer):
                 result.update_invalid_dependencies(non_ignored_depends)
 
                 redundant_dependency_names = find_redundant_dependency_names(local_depends, allowed_dependency_names)
-                result.update_redundant_dependency_names(dependency_input.input_package, redundant_dependency_names)
+                if redundant_dependency_names:
+                    result.update_redundant_dependency_names(dependency_input.input_package, redundant_dependency_names)
         return result
 
 

--- a/pordego_dependency/dependency_tools.py
+++ b/pordego_dependency/dependency_tools.py
@@ -23,6 +23,10 @@ def is_local_package(file_path, local_source_paths):
     return False
 
 
+def find_redundant_dependency_names(dependencies, allowed_dependency_names):
+    return set(allowed_dependency_names) - set([dependency.target_package for dependency in dependencies])
+
+
 def filter_ignored_dependencies(dependencies, ignore_dependency_names):
     return [d for d in dependencies if not is_ignored(d, ignore_dependency_names)]
 

--- a/tests/test_dependency_analysis.py
+++ b/tests/test_dependency_analysis.py
@@ -33,3 +33,15 @@ class DependencyAnalysisTest(unittest.TestCase):
 
         # since IMPORT_LOCAL_DEPS_PKG depends on OTHER_PACKAGE
         self.assertTrue(analyzer.analyze(package_dependency_map).has_error)
+
+    def test_analysis_with_redundancy_in_dependency_map(self):
+        config = DependencyConfig(
+            source_paths=[SOURCE_PATH],
+            analysis_packages=[IMPORT_LOCAL_DEPS_PKG],
+            dependency_map={IMPORT_LOCAL_DEPS_PKG: ["other_package", "some-legacy-dependency"]}
+        )
+        root_cache = preload_packages(config.source_paths)
+        package_dependency_map = build_package_dependencies(config, root_cache)
+
+        analyzer = DependencyAnalyzer(config)
+        self.assertTrue(analyzer.analyze(package_dependency_map).has_error)


### PR DESCRIPTION
Error will be reported if dependency_map contains redundant dependencies. Without that it is easy to have dependency_map which is not up-to-date and contains not valid dependencies.